### PR TITLE
Fix links from mock NICs to mock sled

### DIFF
--- a/mock/redfish/v1/Systems/System-1-1-1-1/EthernetInterfaces/NIC1/index.json
+++ b/mock/redfish/v1/Systems/System-1-1-1-1/EthernetInterfaces/NIC1/index.json
@@ -6,7 +6,7 @@
     "LinkStatus": "LinkUp",
     "Links": {
         "Chassis": {
-            "@odata.id": "/redfish/v1/Chassis/1"
+            "@odata.id": "/redfish/v1/Chassis/Sled-1-1-1"
         }
     },
     "MACAddress": "AB:CD:EF:01:23:45",

--- a/mock/redfish/v1/Systems/System-1-1-1-2/EthernetInterfaces/NIC1/index.json
+++ b/mock/redfish/v1/Systems/System-1-1-1-2/EthernetInterfaces/NIC1/index.json
@@ -6,7 +6,7 @@
     "LinkStatus": "LinkUp",
     "Links": {
         "Chassis": {
-            "@odata.id": "/redfish/v1/Chassis/1"
+            "@odata.id": "/redfish/v1/Chassis/Sled-1-1-1"
         }
     },
     "MACAddress": "AB:CD:EF:01:25:00",

--- a/mock/redfish/v1/Systems/System-1-2-1-1/EthernetInterfaces/NIC1/index.json
+++ b/mock/redfish/v1/Systems/System-1-2-1-1/EthernetInterfaces/NIC1/index.json
@@ -6,7 +6,7 @@
     "LinkStatus": "LinkUp",
     "Links": {
         "Chassis": {
-            "@odata.id": "/redfish/v1/Chassis/1"
+            "@odata.id": "/redfish/v1/Chassis/Sled-1-1-1"
         }
     },
     "MACAddress": "AB:CD:EF:01:24:11",


### PR DESCRIPTION
The NIC resources contained links to non-existing resources. This
rewires them to existing ones.

/cc @tadeboro @mancabizjak 